### PR TITLE
pip3 install httpie

### DIFF
--- a/templates/pww-workshop-env-build.yml
+++ b/templates/pww-workshop-env-build.yml
@@ -734,8 +734,7 @@ Resources:
         ImageId:
           !GetAtt AMIInfo.Id
         InstanceType: !Ref EC2InstanceSize
-        IamInstanceProfile:
-          Ref: EC2InstanceProfile
+        IamInstanceProfile: !Ref EC2InstanceProfile 
         SubnetId:
               Ref: sub2Private          
         Tags:
@@ -748,7 +747,8 @@ Resources:
             yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
             amazon-linux-extras enable python3.8
             amazon-linux-extras install -y python3.8 
-            yum install -y curl git python-pip httpie
+            yum install -y curl git python-pip 
+            pip3 install httpie
             /usr/bin/aws configure set region ${AWS::Region}
             /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource RedTeamHost --configsets Scanner_Install --region ${AWS::Region}
             /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource RedTeamHost --region ${AWS::Region}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/protecting-workloads-workshop/issues/7

*Description of changes:*
Changed the installation of httpie, from `yum` install (which fails) to `pip3` install, this ensures the installation process is successful and that the cfn-signal is sent before the timeout.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

![Screenshot 2021-09-25 at 7 57 01 PM](https://user-images.githubusercontent.com/795867/134828603-bfffad50-842d-4379-bcda-2bb329f498a3.png)

